### PR TITLE
Updates for podspec to support tvOS

### DIFF
--- a/KalturaOttClient.podspec
+++ b/KalturaOttClient.podspec
@@ -7,6 +7,7 @@ s.license          = { :type => 'AGPLv3', :text => 'AGPLv3' }
 s.author           = { 'Kaltura' => 'community@kaltura.com' }
 s.source           = { :git => 'https://github.com/kaltura/KalturaOttGeneratedAPIClientsSwift.git', :tag => s.version.to_s }
 s.ios.deployment_target = '8.0'
+s.tvos.deployment_target = '10.0'
 s.source_files = 'KalturaClient/Classes/**/*'
 
  


### PR DESCRIPTION
Hi guys.
Small update on a podspec file to enable pod install for tvOS targets.
I'm not sure if we can use same tvOS version as for iOS. I put s.tvos.deployment_target to '10.0', because it is minimum version of deployment target in my App.
Thank you!
Sergey
